### PR TITLE
ci: switch to SeaweedFS and upgrade Go to 1.25

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -11,7 +11,7 @@ jobs:
     strategy:
       matrix:
         go-version:
-          - 1.21.x
+          - 1.25.x
         os:
           - ubuntu
 
@@ -31,25 +31,35 @@ jobs:
     strategy:
       matrix:
         go-version:
-          - 1.21.x
+          - 1.25.x
         os:
           - ubuntu
 
     name: test (${{ matrix.os }}/go-${{ matrix.go-version }})
     runs-on: ${{ matrix.os }}-latest
     services:
-      minio:
-        image: ${{ (matrix.os == 'ubuntu') && 'bitnami/minio:2023.7.18' || ''}}
+      seaweedfs:
+        image: ${{ (matrix.os == 'ubuntu') && 'chrislusf/seaweedfs:4.15' || ''}}
+        command: "server -s3"
         ports:
-          - 45677:9000
+          - 45677:8333
         options: >-
-          --health-cmd "curl -I http://localhost:9000/minio/health/live -s"
+          --health-cmd "curl -I http://localhost:8333/status -s"
           --health-interval 10s
           --health-timeout 5s
           --health-retries 5
-        env:
-          MINIO_ROOT_USER: minioadmin
-          MINIO_ROOT_PASSWORD: minioadmin
+      # minio:
+      #   image: ${{ (matrix.os == 'ubuntu') && 'bitnami/minio:2023.7.18' || ''}}
+      #   ports:
+      #     - 45677:9000
+      #   options: >-
+      #     --health-cmd "curl -I http://localhost:9000/minio/health/live -s"
+      #     --health-interval 10s
+      #     --health-timeout 5s
+      #     --health-retries 5
+      #   env:
+      #     MINIO_ROOT_USER: minioadmin
+      #     MINIO_ROOT_PASSWORD: minioadmin
     steps:
     - uses: actions/checkout@v2
     - uses: actions/setup-go@v2

--- a/.github/workflows/goreleaser.yml
+++ b/.github/workflows/goreleaser.yml
@@ -16,7 +16,7 @@ jobs:
         name: Set up Go
         uses: actions/setup-go@v2
         with:
-          go-version: '1.21.7'
+          go-version: '1.25.8'
       -
         name: Run GoReleaser
         uses: goreleaser/goreleaser-action@v2

--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module github.com/voyvodov/goofys
 
-go 1.21
+go 1.25.8
 
 require (
 	cloud.google.com/go/storage v1.30.1


### PR DESCRIPTION
- Replace Minio with SeaweedFS 4.15 in CI test service
- Update Go version from 1.21 to 1.25.x in CI matrix
- Bump go.mod to go 1.25.8